### PR TITLE
Add Missing 0 from HomeKit Auth Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ To install, clone the project into a folder. Then cd to that directory, and run 
 ## Starting HomeKitCaM
 The camera can be run by running the command: node PiCamera_accesory.js 
 
-On any iOS 10 device, open the Home app and add a new accessory. The Raspberry should show up as 'Pi Camera'. When asked to scan the HomeKit accessory code, choose to manually enter a code and enter 31-45-154. After that, the pairing should be successful and the camera should start to send screenshots to the Home app.
+On any iOS 10 device, open the Home app and add a new accessory. The Raspberry should show up as 'Pi Camera'. When asked to scan the HomeKit accessory code, choose to manually enter a code and enter `031-45-154`. After that, the pairing should be successful and the camera should start to send screenshots to the Home app.


### PR DESCRIPTION
The HomeKit authentication code in the ReadMe file is missing a leading `0`.